### PR TITLE
Add differentiate as a synonym for derive

### DIFF
--- a/operations.js
+++ b/operations.js
@@ -9,6 +9,7 @@ module.exports = {
   zeroes: metadelta.zeroes,
   integrate: metadelta.integrate,
   derive: metadelta.derive,
+  differentiate: metadelta.derive,
   cos: metadelta.cos,
   sin: metadelta.sin,
   tan: metadelta.tan,


### PR DESCRIPTION
In some mathematical dialects, derive is rarely used as a verb and instead the act of taking the derivative is referred to as differentiating. I suggest adding it as a synonym for derive just to be familiar to more people.